### PR TITLE
Updated repository link in the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -40,7 +40,7 @@ For Bundle Maintainers
 
 The bundle's source is at the following git repository:
 
-https://github.com/agentzh/ngx_openresty
+https://github.com/openresty/ngx_openresty
 
 To reproduce the bundle tarball, just do
 


### PR DESCRIPTION
The link still pointed to the old agentzh repo.